### PR TITLE
Fix cascading path issues with layout path

### DIFF
--- a/wintersmith-handlebars.coffee
+++ b/wintersmith-handlebars.coffee
@@ -24,10 +24,10 @@ module.exports = (env, callback) ->
       try
         layout = @raw.toString().match(layoutPattern)
         if layout and layout.length
-          @filepath =
+          @layoutpath =
             full: path.join(path.dirname(@filepath.full), layout[1])
             relative: layout[1]
-          HandlebarsTemplate.fromFile @filepath, (error, layout, filepath) =>
+          HandlebarsTemplate.fromFile @layoutpath, (error, layout, filepath) =>
             if error then callback error
             else
               context = extend locals,


### PR DESCRIPTION
This fixes an issue with layout includes in views that if using a layout path of something similar to "../../layouts/layout.html", it will cause cascading issues with the path being overwritten every refresh and page will not load.